### PR TITLE
Improve startup proccess for tilt file

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -34,14 +34,22 @@ helm_resource(
     labels=['data']
 )
 
+
 helm_resource('keda', 'kedacore/keda', labels=['keda'])
 
 k8s_yaml('manifests/ingress.yaml')
+
+
 k8s_yaml('manifests/nfs.yaml')
 k8s_resource('nfs-server', labels=['data'], new_name='nfs')
 
+k8s_yaml('manifests/openfga-migration.yaml')
+k8s_resource("openfga-migration", labels=['migration'], resource_deps=["postgresql"])
 k8s_yaml('manifests/openfga.yaml')
-k8s_resource('openfga', labels=['data'])
+k8s_resource('openfga', labels=['data'], resource_deps=["openfga-migration"])
+
+k8s_yaml('manifests/migration.yaml')
+k8s_resource('virtool-migration', labels=['migration'], resource_deps=["postgresql", "mongo"])
 
 # Actual Virtool stuff.
 if 'ui' in to_edit:
@@ -62,15 +70,33 @@ k8s_resource('virtool-ui', port_forwards=[3000, 9900], labels=['virtool'])
 if 'backend' in to_edit:
     docker_build('ghcr.io/virtool/virtool', '../virtool/')
 
+api_resource_deps=["mongo", "postgresql", "openfga", "nfs", "redis", "virtool-migration"]
+
 k8s_yaml('manifests/api.yaml')
-k8s_resource('virtool-api-web', port_forwards=[9950], labels=['virtool'])
+k8s_resource('virtool-api-web', port_forwards=[9950], labels=['virtool'], resource_deps=api_resource_deps)
 
 k8s_yaml('manifests/jobs_api.yaml')
-k8s_resource('virtool-api-jobs', port_forwards=[9960], labels=['virtool'])
+k8s_resource('virtool-api-jobs', port_forwards=[9960], labels=['virtool'], resource_deps=api_resource_deps)
+
+
+
+
+jobs = ["shared.yaml",'build-index.yaml','create-sample.yaml' ]
 
 k8s_yaml('manifests/jobs/shared.yaml')
+k8s_resource(objects=["virtool-jobs-config"], labels=["jobs"], new_name="Shared")
+
 k8s_yaml('manifests/jobs/build-index.yaml')
+k8s_resource(objects=["virtool-job-build-index"], labels=["jobs"], new_name="build-index", resource_deps=["keda"])
+
 k8s_yaml('manifests/jobs/create-sample.yaml')
+k8s_resource(objects=["virtool-job-create-sample"], labels=["jobs"], new_name="create-sample", resource_deps=["keda"])
+
 k8s_yaml('manifests/jobs/create-subtraction.yaml')
+k8s_resource(objects=["virtool-job-create-subtraction"], labels=["jobs"], new_name="create-subraction", resource_deps=["keda"])
+
 k8s_yaml('manifests/jobs/nuvs.yaml')
+k8s_resource(objects=["virtool-job-nuvs"], labels=["jobs"], new_name="nuvs", resource_deps=["keda"])
+
 k8s_yaml('manifests/jobs/pathoscope.yaml')
+k8s_resource(objects=["virtool-job-pathoscope"], labels=["jobs"], new_name="pathoscope", resource_deps=["keda"])

--- a/manifests/jobs_api.yaml
+++ b/manifests/jobs_api.yaml
@@ -25,7 +25,7 @@ spec:
               value: "/data"
             - name: VT_DB_CONNECTION_STRING
               value: "mongodb://virtool:virtool@mongo-mongodb-0.mongo-mongodb-headless.default.svc.cluster.local/virtool"
-            - name: VT_DB_NAME
+            - name: VT_DB_NAMEz
               value: "virtool"
             - name: VT_OPENFGA_SCHEME
               value: "http"

--- a/manifests/migration.yaml
+++ b/manifests/migration.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: virtool-migration
+  labels:
+    app: VirtoolMigration
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: VirtoolMigration
+    spec:
+      containers:
+        - image: ghcr.io/virtool/migration:1.6.0
+          imagePullPolicy: Always
+          name: virtool-migration
+          env:
+            - name: VT_MIGRATION_APPLY_MONGO_CONNECTION_STRING
+              value: "mongodb://virtool:virtool@mongo-mongodb-0.mongo-mongodb-headless.default.svc.cluster.local/virtool"
+            - name: SQLALCHEMY_URL
+              value: "postgresql+asyncpg://virtool@postgresql.default.svc.cluster.local?password=virtool"
+          resources:
+            limits:
+              cpu: 800m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 1Gi
+      restartPolicy: Never
+

--- a/manifests/mongo_values.yaml
+++ b/manifests/mongo_values.yaml
@@ -1,9 +1,16 @@
 architecture: replicaset
+replicaCount: 1
 auth:
   replicaSetKey: virtool
+  rootpassword: virtool
   passwords:
     - virtool
   usernames:
     - virtool
   databases:
     - virtool
+arbiter:
+  enabled: false
+
+
+

--- a/manifests/openfga-migration.yaml
+++ b/manifests/openfga-migration.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openfga-migration
+  labels:
+    app: OpenFGA
+spec:  
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: OpenFGA
+    spec:
+      containers:
+        - name: openfga-migration
+          image: openfga/openfga:v0.2.5
+          command: ["./openfga", "migrate"]
+          env:
+            - name: OPENFGA_DATASTORE_ENGINE
+              value: "postgres"
+            - name: OPENFGA_DATASTORE_URI
+              value: "postgresql://virtool@postgresql.default.svc.cluster.local/virtool?password=virtool"
+      restartPolicy: Never

--- a/manifests/ui.yaml
+++ b/manifests/ui.yaml
@@ -15,7 +15,7 @@ spec:
         app: VirtoolUI
     spec:
       containers:
-        - image: ghcr.io/virtool/ui:3.4.0
+        - image: ghcr.io/virtool/ui:3.5.1
           imagePullPolicy: Always
           name: virtool-ui
           command: ["node", "run.js"]


### PR DESCRIPTION
With changes the file now starts up with no failures from clean slate. (ie after running `minikube delete`)

Changes: 
 - startup containers only after required resources are ready
  - remove redudant mongo replicas and arbiter
  - add openFGA migration as job to be run at startup
  - add virtool migration as job to be run at startup
