### PR TITLE
Migration and --no-tasks

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -51,6 +51,9 @@ k8s_resource("openfga-migration", labels=['migration'], resource_deps=["postgres
 k8s_yaml('manifests/openfga.yaml')
 k8s_resource('openfga', labels=['data'], resource_deps=["openfga-migration"], port_forwards=[8080])
 
+if 'migration' in to_edit:
+    docker_build('ghcr.io/virtool/migration', '../virtool-migration/')
+
 k8s_yaml('manifests/migration.yaml')
 k8s_resource('virtool-migration', labels=['migration'], resource_deps=["postgresql", "mongo"])
 

--- a/manifests/api.yaml
+++ b/manifests/api.yaml
@@ -19,7 +19,7 @@ spec:
         - image: ghcr.io/virtool/virtool:15.1.1
           imagePullPolicy: Always
           name: virtool-api-web
-          command: ["python", "run.py", "server"]
+          command: ["python", "run.py", "--no-tasks", "server"]
           env:
             - name: VT_DATA_PATH
               value: "/data"


### PR DESCRIPTION
* Allow live editing of the migration image.
* Run both API services with the `--no-tasks` option.