### PR TITLE
Add clean db command

### DIFF
--- a/manifests/api-jobs.yaml
+++ b/manifests/api-jobs.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:19.4.0
+        - image: ghcr.io/virtool/virtool:20.0.1
           imagePullPolicy: Always
           name: virtool-api-jobs
           command: ["python", "run.py", "server", "jobs"]
@@ -46,11 +46,11 @@ spec:
               cpu: 600m
               memory: 1Gi
           volumeMounts:
-          - name: data
-            mountPath: /data
+            - name: data
+              mountPath: /data
       volumes:
-      - name: data
-        nfs:
+        - name: data
+          nfs:
             server: 10.109.28.120
             path: /
 ---

--- a/manifests/api-web.yaml
+++ b/manifests/api-web.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:19.4.0
+        - image: ghcr.io/virtool/virtool:20.0.1
           imagePullPolicy: Always
           name: virtool-api-web
           command: ["python", "run.py", "server", "api"]
@@ -46,14 +46,13 @@ spec:
               cpu: 600m
               memory: 1Gi
           volumeMounts:
-          - name: data
-            mountPath: /data
+            - name: data
+              mountPath: /data
       volumes:
-      - name: data
-        nfs:
+        - name: data
+          nfs:
             server: 10.109.28.120
             path: /
-
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/jobs/nuvs.yaml
+++ b/manifests/jobs/nuvs.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-nuvs
-            image: ghcr.io/virtool/nuvs:5.1.0
+            image: ghcr.io/virtool/nuvs:5.1.1
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/jobs/pathoscope.yaml
+++ b/manifests/jobs/pathoscope.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-pathoscope
-            image: ghcr.io/virtool/pathoscope:5.2.0
+            image: ghcr.io/virtool/pathoscope:5.3.2
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/migration.yaml
+++ b/manifests/migration.yaml
@@ -12,9 +12,9 @@ spec:
         app: VirtoolMigration
     spec:
       containers:
-        - image: ghcr.io/virtool/virtool:19.4.0
+        - image: ghcr.io/virtool/virtool:20.0.1
           name: virtool-migration
-          command: [ "python", "run.py", "migration", "apply" ]
+          command: ["python", "run.py", "migration", "apply"]
           env:
             - name: VT_DATA_PATH
               value: "/data"
@@ -41,8 +41,8 @@ spec:
               cpu: 200m
               memory: 1Gi
           volumeMounts:
-          - name: data
-            mountPath: /data
+            - name: data
+              mountPath: /data
       restartPolicy: Never
       volumes:
         - name: data

--- a/manifests/openfga-migration.yaml
+++ b/manifests/openfga-migration.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openfga-migration
   labels:
     app: OpenFGAMigration
-spec:  
+spec:
   backoffLimit: 0
   template:
     metadata:

--- a/manifests/openfga.yaml
+++ b/manifests/openfga.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/task-runner.yaml
+++ b/manifests/task-runner.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:19.4.0
+        - image: ghcr.io/virtool/virtool:20.0.1
           imagePullPolicy: Always
           name: virtool-task-runner
           command: ["python", "run.py", "tasks", "runner"]
@@ -36,8 +36,8 @@ spec:
             - name: VT_REDIS_CONNECTION_STRING
               value: "redis://:virtool@redis-master.default.svc.cluster.local"
           ports:
-          - containerPort: 9950
-            protocol: TCP
+            - containerPort: 9950
+              protocol: TCP
           resources:
             limits:
               cpu: 1000m
@@ -46,11 +46,11 @@ spec:
               cpu: 600m
               memory: 1Gi
           volumeMounts:
-          - name: data
-            mountPath: /data
+            - name: data
+              mountPath: /data
       volumes:
-      - name: data
-        nfs:
+        - name: data
+          nfs:
             server: 10.109.28.120
             path: /
 ---

--- a/manifests/task-spawner.yaml
+++ b/manifests/task-spawner.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:19.4.0
+        - image: ghcr.io/virtool/virtool:20.0.1
           imagePullPolicy: Always
           name: virtool-task-spawner
           command: ["python", "run.py", "tasks", "spawner"]
@@ -30,8 +30,8 @@ spec:
             - name: VT_REDIS_CONNECTION_STRING
               value: "redis://:virtool@redis-master.default.svc.cluster.local"
           ports:
-          - containerPort: 9950
-            protocol: TCP
+            - containerPort: 9950
+              protocol: TCP
           resources:
             limits:
               cpu: 500m

--- a/manifests/ui.yaml
+++ b/manifests/ui.yaml
@@ -15,7 +15,7 @@ spec:
         app: VirtoolUI
     spec:
       containers:
-        - image: ghcr.io/virtool/ui:3.11.0
+        - image: ghcr.io/virtool/ui:3.12.3
           imagePullPolicy: Always
           name: virtool-ui
           command: ["node", "run.js"]

--- a/update/run.py
+++ b/update/run.py
@@ -23,8 +23,6 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 YAML_DIRECTORIES = [
     "manifests",
     "manifests/jobs",
-    "manifests/tasks",
-    "manifests/tasks/task_yaml",
 ]
 
 


### PR DESCRIPTION
Changes:
 - Brings images up to date
 - Adds a new boolean "persistence" param which when set to `False` spins up a brand new and volatile instance of virtool. Essentially allows running the server in a `volatile` and `persistent` mode. Volatile servers are always empty on startup and operate independently of the persistent data. 