### PR TITLE
Prevent mongo crash

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -27,7 +27,7 @@ helm_resource(
 helm_resource(
     'postgresql',
     'bitnami/postgresql',
-    flags=["--set", "image.tag=15.4.0-debian-11-r47","--set", "auth.username=virtool", "--set", "auth.password=virtool", "--set", "auth.database=virtool", "--set", "primary.persistence.enabled={}".format(persistence)],
+    flags=["--set", "image.tag=15.6.0-debian-11-r16","--set", "auth.username=virtool", "--set", "auth.password=virtool", "--set", "auth.database=virtool", "--set", "primary.persistence.enabled={}".format(persistence)],
     port_forwards=[5432],
     labels=['data']
 )

--- a/manifests/mongo_values.yaml
+++ b/manifests/mongo_values.yaml
@@ -11,6 +11,10 @@ auth:
     - virtool
 arbiter:
   enabled: false
-
-
-
+resources:
+  requests:
+    cpu: 500m
+    memory: 500Mi
+  limits:
+    cpu: 500m
+    memory: 2Gi


### PR DESCRIPTION
Changes:
 - Updates postgres to latest debian 11 based image, overcoming a problem where the DB would fail to initialize when running a fresh instance
 - Increases mongo memory limits from 750Mi to 2Gi to allow mongo to allocate a large storage engine cache. Prevents a crash when installing remote refs