### PR TITLE
Support UI api checks

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -81,7 +81,7 @@ if 'ui' in to_edit:
     )
 
 k8s_yaml('manifests/ui.yaml')
-k8s_resource('virtool-ui', port_forwards=[9900], labels=['virtool'])
+k8s_resource('virtool-ui', port_forwards=[9900], labels=['virtool'], resource_deps=["virtool-api-web"])
 
 if 'backend' in to_edit:
     docker_build(

--- a/manifests/api-jobs.yaml
+++ b/manifests/api-jobs.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:23.2.0
+        - image: ghcr.io/virtool/virtool:23.4.1
           imagePullPolicy: Always
           name: virtool-api-jobs
           command: ["python", "run.py", "server", "jobs"]

--- a/manifests/api-web.yaml
+++ b/manifests/api-web.yaml
@@ -48,6 +48,12 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+          startupProbe:
+            httpGet:
+              path: /
+              port: 9950
+            initialDelaySeconds: 3
+            periodSeconds: 3
       volumes:
         - name: data
           nfs:

--- a/manifests/api-web.yaml
+++ b/manifests/api-web.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:23.2.0
+        - image: ghcr.io/virtool/virtool:23.4.1
           imagePullPolicy: Always
           name: virtool-api-web
           command: ["python", "run.py", "server", "api"]

--- a/manifests/jobs/build-index.yaml
+++ b/manifests/jobs/build-index.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-build-index
-            image: ghcr.io/virtool/build-index:5.2.0
+            image: ghcr.io/virtool/build-index:5.3.0
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/jobs/create-sample.yaml
+++ b/manifests/jobs/create-sample.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-create-sample
-            image: ghcr.io/virtool/create-sample:4.1.4
+            image: ghcr.io/virtool/create-sample:4.2.0
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/jobs/create-subtraction.yaml
+++ b/manifests/jobs/create-subtraction.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-create-subtraction
-            image: ghcr.io/virtool/create-subtraction:5.1.2
+            image: ghcr.io/virtool/create-subtraction:5.2.0
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/jobs/nuvs.yaml
+++ b/manifests/jobs/nuvs.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-nuvs
-            image: ghcr.io/virtool/nuvs:5.2.3
+            image: ghcr.io/virtool/nuvs:5.3.0
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/jobs/pathoscope.yaml
+++ b/manifests/jobs/pathoscope.yaml
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
           - name: job-pathoscope
-            image: ghcr.io/virtool/pathoscope:5.5.0
+            image: ghcr.io/virtool/pathoscope:5.6.1
             imagePullPolicy: Always
             command: [run-workflow]
             envFrom:

--- a/manifests/migration.yaml
+++ b/manifests/migration.yaml
@@ -12,7 +12,7 @@ spec:
         app: VirtoolMigration
     spec:
       containers:
-        - image: ghcr.io/virtool/virtool:23.2.0
+        - image: ghcr.io/virtool/virtool:23.4.1
           name: virtool-migration
           command: ["python", "run.py", "migration", "apply"]
           env:

--- a/manifests/task-runner.yaml
+++ b/manifests/task-runner.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:23.2.0
+        - image: ghcr.io/virtool/virtool:23.4.1
           imagePullPolicy: Always
           name: virtool-task-runner
           command: ["python", "run.py", "tasks", "runner"]

--- a/manifests/task-spawner.yaml
+++ b/manifests/task-spawner.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: ghcr.io/virtool/virtool:23.2.0
+        - image: ghcr.io/virtool/virtool:23.4.1
           imagePullPolicy: Always
           name: virtool-task-spawner
           command: ["python", "run.py", "tasks", "spawner"]

--- a/manifests/ui.yaml
+++ b/manifests/ui.yaml
@@ -15,7 +15,7 @@ spec:
         app: VirtoolUI
     spec:
       containers:
-        - image: ghcr.io/virtool/ui:5.1.0
+        - image: ghcr.io/virtool/ui:5.19.1
           imagePullPolicy: Always
           name: virtool-ui
           command: ["node", "run.js"]

--- a/manifests/ui.yaml
+++ b/manifests/ui.yaml
@@ -25,7 +25,7 @@ spec:
             - name: VT_UI_HOST
               value: "0.0.0.0"
             - name: VT_UI_API_URL
-              value: "https://localhost:9900/api"
+              value: "http://api-service.default.svc.cluster.local"
           ports:
             - containerPort: 9900
               protocol: TCP


### PR DESCRIPTION
Add support for incoming backend API version checks from the UI container. Compatible with current UI versions

Changes: 
 - add startup probe for web-api that checks for API functionality
 - make tilt wait to start the UI until web-api is ready
 - update API URL in UI configuration to correctly target the API container from within minikube
 - updates all container images to latest