### PR TITLE
fix: limit resource requests and limits

### DIFF
--- a/manifests/api-jobs.yaml
+++ b/manifests/api-jobs.yaml
@@ -42,11 +42,11 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
               cpu: 600m
-              memory: 1Gi
+              memory: 800M
+            requests:
+              cpu: 400m
+              memory: 400M
           volumeMounts:
             - name: data
               mountPath: /data

--- a/manifests/api-web.yaml
+++ b/manifests/api-web.yaml
@@ -42,11 +42,11 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
               cpu: 600m
-              memory: 1Gi
+              memory: 800M
+            requests:
+              cpu: 40000m
+              memory: 400M
           volumeMounts:
             - name: data
               mountPath: /data

--- a/manifests/openfga.yaml
+++ b/manifests/openfga.yaml
@@ -31,8 +31,8 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 900m
-              memory: 1G
+              cpu: 600m
+              memory: 400M
             requests:
               cpu: 300m
               memory: 300M

--- a/manifests/task-runner.yaml
+++ b/manifests/task-runner.yaml
@@ -42,9 +42,11 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+              ephemeral-storage: 1Gi
             requests:
               cpu: 600m
               memory: 1Gi
+              ephemeral-storage: 1Gi
           volumeMounts:
             - name: data
               mountPath: /data

--- a/manifests/task-spawner.yaml
+++ b/manifests/task-spawner.yaml
@@ -34,11 +34,11 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
               cpu: 400m
-              memory: 1Gi
+              memory: 600M
+            requests:
+              cpu: 200m
+              memory: 300M
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/ui.yaml
+++ b/manifests/ui.yaml
@@ -31,11 +31,11 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 2
-              memory: 3Gi
+              cpu: 200m
+              memory: 300M
             requests:
-              cpu: 2
-              memory: 3Gi
+              cpu: 100m
+              memory: 150M
       restartPolicy: Always
 ---
 apiVersion: v1


### PR DESCRIPTION
Resource settings for Virtool workloads have been reduced in production as we track metrics.

This PR adjusts settings to lower values that we have found to be sufficient.

